### PR TITLE
Edge build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,8 @@ jobs:
               if [[ -n $result ]]; then
                 echo "***** Config Import - ${site} *****"
                 platform drush "cim -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
+                echo "***** Enable QA accounts - ${site} *****"
+                platform drush "bulk_update_qa_accounts enable -l ${site}" -y -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
               fi
             done
       - run:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,114 +1,105 @@
 name: unity_svr_2
 type: 'php:8.0'
 dependencies:
-  php:
-    composer/composer: ^2
+    php:
+        composer/composer: ^2
 runtime:
-  extensions:
-    - apcu
-    - redis
+    extensions:
+        - apcu
+        - redis
 disk: 8000
 mounts:
-  /web/files:
-    source: local
-    source_path: files
-  /tmp:
-    source: local
-    source_path: tmp
-  /private:
-    source: local
-    source_path: private
-  /.drush:
-    source: local
-    source_path: drush
-  /drush-backups:
-    source: local
-    source_path: drush-backups
-  /.console:
-    source: local
-    source_path: console
-  '/log':
-    source: local
-    source_path: 'log'
+    /web/files:
+        source: local
+        source_path: files
+    /tmp:
+        source: local
+        source_path: tmp
+    /private:
+        source: local
+        source_path: private
+    /.drush:
+        source: local
+        source_path: drush
+    /drush-backups:
+        source: local
+        source_path: drush-backups
+    /.console:
+        source: local
+        source_path: console
 build:
-  flavor: composer
+    flavor: composer
 hooks:
-  build: "set -e\n"
-  post_deploy: "set -e\n\n# Save the Fastly service value and overwrite with a dummy one in order to break\n# the connection to Fastly, otherwise any cache clear of any site will purge the\n# entire Fastly cache - we don't want this to happen as we'd like Fastly to continue\n# serving the sites to anonymous users during a release.\necho \"***** Breaking connection to Fastly ******\"\ntemp=$FASTLY_API_SERVICE\nexport FASTLY_API_SERVICE=dummyservice\n\n# For each multi site - run db-updates and import config.\nfor site in mentalhealthchampionni publicappointmentsni ircommission imtac nicertoffice victimspaymentsboard default hiaredressni\ndo\n  echo \"****** $site deployment ******\"\n  cd /app/web/sites/$site\n  # Disable Fastly logging\n  drush -l $site disable-fastly-logging\n  # Readonlymode module should be installed on all sites,\n  # but we'll just make sure.\n  drush en readonlymode -l $site -y\n  # Set site to readonly just in case editors are logged on.\n  drush -l $site cset readonlymode.settings enabled 1 -y\n  drush -l $site -y cache-rebuild\n  drush -l $site -y config-import\n  drush -l $site -y updatedb\n  drush -l $site import-all-if-installed safe\n  # Turn off readonly mode.\n  drush -l $site cset readonlymode.settings enabled 0 -y\ndone\n\n# Reconnect to Fastly\necho \"***** Reinstate connection to Fastly ******\"\nexport FASTLY_API_SERVICE=$temp\n\n# For each multi site - clear cache (including Fastly cache)\nfor site in mentalhealthchampionni publicappointmentsni ircommission imtac nicertoffice victimspaymentsboard default hiaredressni\ndo\n  echo \"****** $site cache clear ******\"\n  cd /app/web/sites/$site\n  drush -l $site -y cache-rebuild\n  # Enable Fastly logging\n  drush -l $site enable-fastly-logging\ndone\n"
+    build: "set -e\n"
+    post_deploy: "set -e\n\n# Save the Fastly service value and overwrite with a dummy one in order to break\n# the connection to Fastly, otherwise any cache clear of any site will purge the\n# entire Fastly cache - we don't want this to happen as we'd like Fastly to continue\n# serving the sites to anonymous users during a release.\necho \"***** Breaking connection to Fastly ******\"\ntemp=$FASTLY_API_SERVICE\nexport FASTLY_API_SERVICE=dummyservice\n\n# For each multi site - run db-updates and import config.\nfor site in mentalhealthchampionni publicappointmentsni ircommission imtac nicertoffice victimspaymentsboard default hiaredressni\ndo\n  echo \"****** $site deployment ******\"\n  cd /app/web/sites/$site\n  # Disable Fastly logging\n  drush -l $site disable-fastly-logging\n  # Readonlymode module should be installed on all sites,\n  # but we'll just make sure.\n  drush en readonlymode -l $site -y\n  # Set site to readonly just in case editors are logged on.\n  drush -l $site cset readonlymode.settings enabled 1 -y\n  drush -l $site -y cache-rebuild\n  drush -l $site -y config-import\n  drush -l $site -y updatedb\n  drush -l $site import-all-if-installed safe\n  # Turn off readonly mode.\n  drush -l $site cset readonlymode.settings enabled 0 -y\ndone\n\n# Reconnect to Fastly\necho \"***** Reinstate connection to Fastly ******\"\nexport FASTLY_API_SERVICE=$temp\n\n# For each multi site - clear cache (including Fastly cache)\nfor site in mentalhealthchampionni publicappointmentsni ircommission imtac nicertoffice victimspaymentsboard default hiaredressni\ndo\n  echo \"****** $site cache clear ******\"\n  cd /app/web/sites/$site\n  drush -l $site -y cache-rebuild\n  # Enable Fastly logging\n  drush -l $site enable-fastly-logging\ndone\n"
 web:
-  locations:
-    /:
-      root: web
-      expires: 5m
-      passthru: /index.php
-      allow: false
-      rules:
-        '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
-          allow: true
-        ^/robots\.txt$:
-          allow: true
-        ^/sitemap\.xml$:
-          allow: true
-        ^\/sites\/.+\/themes\/.+\/images\/favicons\/.+\.webmanifest$:
-          allow: true
-          expires: 2w
-        ^/sites/sites\.php$:
-          scripts: false
-        '^/sites/[^/]+/settings.*?\.php$':
-          scripts: false
-    /files:
-      allow: true
-      expires: 1d
-      passthru: /index.php
-      root: web/files
-      scripts: false
-      rules:
-        ^/sites/default/files/(css|js):
-          expires: 2w
+    locations:
+        /:
+            root: web
+            expires: 5m
+            passthru: /index.php
+            allow: false
+            rules:
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                ^/robots\.txt$:
+                    allow: true
+                ^/sitemap\.xml$:
+                    allow: true
+                ^\/sites\/.+\/themes\/.+\/images\/favicons\/.+\.webmanifest$:
+                    allow: true
+                    expires: 2w
+                ^/sites/sites\.php$:
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+        /files:
+            allow: true
+            expires: 1d
+            passthru: /index.php
+            root: web/files
+            scripts: false
+            rules:
+                ^/sites/default/files/(css|js):
+                    expires: 2w
 relationships:
-  mentalhealthchampionni: 'db:mentalhealthchampionni'
-  mentalhealthchampionni_solr: 'solr:mentalhealthchampionni'
-  publicappointmentsni: 'db:publicappointmentsni'
-  publicappointmentsni_solr: 'solr:publicappointmentsni'
-  ircommission: 'db:ircommission'
-  ircommission_solr: 'solr:ircommission'
-  imtac: 'db:imtac'
-  imtac_solr: 'solr:imtac'
-  nicertoffice: 'db:nicertoffice'
-  nicertoffice_solr: 'solr:nicertoffice'
-  victimspaymentsboard: 'db:victimspaymentsboard'
-  victimspaymentsboard_solr: 'solr:victimspaymentsboard'
-  default: 'db:default'
-  hiaredressni: 'db:hiaredressni'
-  hiaredressni_solr: 'solr:hiaredressni'
+    mentalhealthchampionni: 'db:mentalhealthchampionni'
+    mentalhealthchampionni_solr: 'solr:mentalhealthchampionni'
+    publicappointmentsni: 'db:publicappointmentsni'
+    publicappointmentsni_solr: 'solr:publicappointmentsni'
+    ircommission: 'db:ircommission'
+    ircommission_solr: 'solr:ircommission'
+    imtac: 'db:imtac'
+    imtac_solr: 'solr:imtac'
+    nicertoffice: 'db:nicertoffice'
+    nicertoffice_solr: 'solr:nicertoffice'
+    victimspaymentsboard: 'db:victimspaymentsboard'
+    victimspaymentsboard_solr: 'solr:victimspaymentsboard'
+    default: 'db:default'
+    hiaredressni: 'db:hiaredressni'
+    hiaredressni_solr: 'solr:hiaredressni'
 crons:
-  mentalhealthchampionni:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/mentalhealthchampionni ; drush core-cron'
-  publicappointmentsni:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/publicappointmentsni ; drush core-cron'
-  ircommission:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/ircommission ; drush core-cron'
-  imtac:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/imtac ; drush core-cron'
-  nicertoffice:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/nicertoffice ; drush core-cron'
-  victimspaymentsboard:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/victimspaymentsboard ; drush core-cron'
-  default:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/default ; drush core-cron'
-  hiaredressni:
-    spec: '10 * * * *'
-    cmd: 'cd web/sites/hiaredressni ; drush core-cron'
-  # Log shipping cron.
-  logging:
-    spec: '*/5 * * * *'
-    commands:
-      start: '/bin/bash /app/cronjob.sh'
-    shutdown_timeout: 290
+    mentalhealthchampionni:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/mentalhealthchampionni ; drush core-cron'
+    publicappointmentsni:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/publicappointmentsni ; drush core-cron'
+    ircommission:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/ircommission ; drush core-cron'
+    imtac:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/imtac ; drush core-cron'
+    nicertoffice:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/nicertoffice ; drush core-cron'
+    victimspaymentsboard:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/victimspaymentsboard ; drush core-cron'
+    default:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/default ; drush core-cron'
+    hiaredressni:
+        spec: '10 * * * *'
+        cmd: 'cd web/sites/hiaredressni ; drush core-cron'

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -6,14 +6,6 @@
 'https://mentalhealthchampion-ni.org.uk.{default}/':
     type: redirect
     to: 'https://www.mentalhealthchampion-ni.org.uk.{default}/'
-'https://www.publicappointmentsni.org/':
-    type: upstream
-    upstream: 'unity_svr_2:http'
-    cache:
-        enabled: 'false'
-'https://publicappointmentsni.org/':
-    type: redirect
-    to: 'https://www.publicappointmentsni.org/'
 'https://www.ircommission.org/':
     type: upstream
     upstream: 'unity_svr_2:http'

--- a/project/config/publicappointmentsni/config/core.extension.yml
+++ b/project/config/publicappointmentsni/config/core.extension.yml
@@ -91,6 +91,7 @@ module:
   origins_common: 0
   origins_media: 0
   origins_metatag: 0
+  origins_qa: 0
   origins_toc: 0
   origins_translations: 0
   origins_unique_title: 0

--- a/project/config/publicappointmentsni/config/system.site.yml
+++ b/project/config/publicappointmentsni/config/system.site.yml
@@ -3,7 +3,7 @@ _core:
 langcode: en
 uuid: 569c8fd6-907b-4b87-85a5-15f03e398b03
 name: 'The Commissioner for Public Appointments for Northern Ireland'
-mail: test@test.com
+mail: info@publicappointmentsni.org
 slogan: ''
 page:
   403: ''

--- a/project/project.yml
+++ b/project/project.yml
@@ -17,7 +17,7 @@ sites:
         cron_spec: '10 * * * *'
         cron_cmd: 'cd web/sites/publicappointmentsni ; drush core-cron'
         database: publicappointmentsni
-        status: development
+        status: production
         default: false
     ircommission:
         name: 'Independent Reporting Commission'


### PR DESCRIPTION
- enable QA accounts as part of nightly edge build
- set site email address on public appointments
- install origins_qa module on public appointments
- set public appointments to ‘production’ and remove explicit route
