### PR TITLE
D8UN-3412

### DIFF
--- a/project/sites/victimspaymentsboard/themes/victimspaymentsboard_theme/templates/field/field--node--field-publication-attachment--full--publication-page.html.twig
+++ b/project/sites/victimspaymentsboard/themes/victimspaymentsboard_theme/templates/field/field--node--field-publication-attachment--full--publication-page.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * - node_id: Finding the node id of the help viewing documnents node on the
+ *   a per unity site basis. See nicsdru_unity_theme_preprocess_field().
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% set title_classes = [
+  label_display == 'visually_hidden' ? 'visually-hidden',
+  'content-field__label',
+] %}
+
+<div{{ attributes.addClass('content-field--label-inline').setAttribute('role', 'presentation') }}>
+  <h2{{ title_attributes.addClass(title_classes) }}>
+    {{ 'Documents'|t }}
+  </h2>
+  <div class="content-field__value">
+    <ul class="list--no-bullet">
+      {% for item in items %}
+        <li{{ item.attributes.addClass('list-item') }}>
+          {{ item.content }}
+        </li>
+      {% endfor %}
+    </ul>
+
+    {% if node_id is not empty %}
+      <p class="help-viewing-documents">
+        <a href="{{ path('entity.node.canonical', {'node': 121}) }}">
+          {{ 'Help viewing documents'|t }}
+        </a>
+      </p>
+    {% endif %}
+  </div>
+</div>

--- a/project/sites/victimspaymentsboard/themes/victimspaymentsboard_theme/victimspaymentsboard_theme.theme
+++ b/project/sites/victimspaymentsboard/themes/victimspaymentsboard_theme/victimspaymentsboard_theme.theme
@@ -1,4 +1,7 @@
 <?php
+
+use Drupal\node\Entity\Node;
+
 /**
  * Implements hook_theme_suggestions_HOOK_alter() for form templates.
  * @param array $suggestions
@@ -18,6 +21,21 @@ function victimspaymentsboard_theme_theme_preprocess_html(&$variables) {
     if (($variables['node_type'] == 'basic_page') || ($variables['node_type'] == 'publication_page')) {
       $variables['attributes']['class'][] = 'one-sidebar';
       $variables['attributes']['class'][] = 'sidebar-second';
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function victimspaymentsboard_theme_preprocess_field(&$variables) {
+
+  if ($variables['field_name'] == 'field_publication_attachment') {
+    $path = \Drupal::service('path_alias.manager')
+      ->getPathByAlias('/help-viewing-documents');
+    if (preg_match('/node\/(\d+)/', $path, $matches)) {
+      $node = Node::load($matches[1]);
+      $variables['node_id'] = $node->id();
     }
   }
 }


### PR DESCRIPTION
- Fixing Help Viewing Documents link on publication pages
- Styling of publication pages was not consistent with other unity sites due to field name incorrectly named - field_publication_attachment instead of field_attachment.
- Some custom code was required to fix.