### PR TITLE
D8UN-3543 (D8UN-3548 - Unity 2)

### DIFF
--- a/project/config/communityrelations/config/core.extension.yml
+++ b/project/config/communityrelations/config/core.extension.yml
@@ -99,6 +99,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -133,7 +134,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/cosicani/config/core.extension.yml
+++ b/project/config/cosicani/config/core.extension.yml
@@ -103,6 +103,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -140,7 +141,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_map_embed: 0
   unity_search_pages: 0

--- a/project/config/cvocni/config/core.extension.yml
+++ b/project/config/cvocni/config/core.extension.yml
@@ -98,12 +98,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -135,7 +136,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/hiaredressni/config/core.extension.yml
+++ b/project/config/hiaredressni/config/core.extension.yml
@@ -92,12 +92,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -127,7 +128,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/imtac/config/core.extension.yml
+++ b/project/config/imtac/config/core.extension.yml
@@ -97,12 +97,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -135,7 +136,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_map_block: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/ircommission/config/core.extension.yml
+++ b/project/config/ircommission/config/core.extension.yml
@@ -96,12 +96,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -131,7 +132,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/mentalhealthchampionni/config/core.extension.yml
+++ b/project/config/mentalhealthchampionni/config/core.extension.yml
@@ -92,13 +92,14 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
   origins_translations: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -128,7 +129,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/nicertoffice/config/core.extension.yml
+++ b/project/config/nicertoffice/config/core.extension.yml
@@ -99,6 +99,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -135,7 +136,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/nicybersecuritycentre/config/core.extension.yml
+++ b/project/config/nicybersecuritycentre/config/core.extension.yml
@@ -102,12 +102,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -141,7 +142,6 @@ module:
   unity_events: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/nijac/config/core.extension.yml
+++ b/project/config/nijac/config/core.extension.yml
@@ -103,6 +103,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -141,7 +142,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_map_block: 0
   unity_search_pages: 0

--- a/project/config/ppsni/config/core.extension.yml
+++ b/project/config/ppsni/config/core.extension.yml
@@ -99,6 +99,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -136,7 +137,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/publicappointmentsni/config/core.extension.yml
+++ b/project/config/publicappointmentsni/config/core.extension.yml
@@ -95,13 +95,14 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
   origins_translations: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -132,7 +133,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/sentencereview/config/core.extension.yml
+++ b/project/config/sentencereview/config/core.extension.yml
@@ -92,12 +92,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -127,7 +128,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/victimspaymentsboard/config/core.extension.yml
+++ b/project/config/victimspaymentsboard/config/core.extension.yml
@@ -92,12 +92,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -127,7 +128,6 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0


### PR DESCRIPTION
- Unity Internal Link checker module uninstalled on all Unity 2 sites
- Origins Internal Link checker module installed on all Unity 2 sites
- No config existed on any of these sites for the previous module.