### PR TITLE
Edge fix

### DIFF
--- a/project/config/cvocni/config/core.extension.yml
+++ b/project/config/cvocni/config/core.extension.yml
@@ -136,6 +136,7 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
+  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/cvocni/config/unity_internal_link_checker.linksettings.yml
+++ b/project/config/cvocni/config/unity_internal_link_checker.linksettings.yml
@@ -1,2 +1,0 @@
-site_url_list: ''
-site_url_list_exclude: ''

--- a/project/config/hiaredressni/config/core.extension.yml
+++ b/project/config/hiaredressni/config/core.extension.yml
@@ -128,6 +128,7 @@ module:
   unity_common: 0
   unity_frontpage: 0
   unity_image_styles: 0
+  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/hiaredressni/config/unity_internal_link_checker.linksettings.yml
+++ b/project/config/hiaredressni/config/unity_internal_link_checker.linksettings.yml
@@ -1,2 +1,0 @@
-site_url_list: ''
-site_url_list_exclude: ''


### PR DESCRIPTION
Unity internal link checker settings don't delete when uninstalling the module. So we have to delete the settings 1st.